### PR TITLE
Refactored code

### DIFF
--- a/SMCWrapper/SMCWrapper.h
+++ b/SMCWrapper/SMCWrapper.h
@@ -1,49 +1,165 @@
-//
-//  SMCWrapper.m
-//  SMCInfo
-//
-//  Created by Fergus Morrow on 27/09/2014, based on work by Apple Corp.
-//  Licensed under the GNU General Public License.
+/*
+ * Apple System Management Control (SMC) Tool
+ * Copyright (C) 2006 devnull
+ * Portions Copyright (C) 2012 Alex Leigh
+ * Portions Copyright (C) 2013 Michael Wilber
+ * Portions Copyright (C) 2013 Jedda Wignall
+ * Portions Copyright (C) 2014 Perceval Faramaz
+ * Portions Copyright (C) 2014 Fergus Morrow
+ * Portions Copyright (C) 2014 Naoya Sato
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
 
-#import <stdio.h>
-#import <string.h>
-#import <IOKit/IOKitLib.h>
-#import <Foundation/Foundation.h>
-#import "smc.h"
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+#include <sys/cdefs.h>
+#include <Availability.h>
+
+#ifndef __SMC_H__
+#define __SMC_H__
+#endif
+
+#define KERNEL_INDEX_SMC      2
+
+#define SMC_CMD_READ_BYTES    5
+#define SMC_CMD_WRITE_BYTES   6
+#define SMC_CMD_READ_INDEX    8
+#define SMC_CMD_READ_KEYINFO  9
+#define SMC_CMD_READ_PLIMIT   11
+#define SMC_CMD_READ_VERS     12
+
+#define DATATYPE_FP1F         "fp1f"
+#define DATATYPE_FP4C         "fp4c"
+#define DATATYPE_FP5B         "fp5b"
+#define DATATYPE_FP6A         "fp6a"
+#define DATATYPE_FP79         "fp79"
+#define DATATYPE_FP88         "fp88"
+#define DATATYPE_FPA6         "fpa6"
+#define DATATYPE_FPC4         "fpc4"
+#define DATATYPE_FPE2         "fpe2"
+
+#define DATATYPE_SP1E         "sp1e"
+#define DATATYPE_SP3C         "sp3c"
+#define DATATYPE_SP4B         "sp4b"
+#define DATATYPE_SP5A         "sp5a"
+#define DATATYPE_SP69         "sp69"
+#define DATATYPE_SP78         "sp78"
+#define DATATYPE_SP87         "sp87"
+#define DATATYPE_SP96         "sp96"
+#define DATATYPE_SPB4         "spb4"
+#define DATATYPE_SPF0         "spf0"
+
+#define DATATYPE_UINT8        "ui8 "
+#define DATATYPE_UINT16       "ui16"
+#define DATATYPE_UINT32       "ui32"
+
+#define DATATYPE_SI8          "si8 "
+#define DATATYPE_SI16         "si16"
+
+#define DATATYPE_PWM          "{pwm"
+#define DATATYPE_LSO          "{lso"
+#define DATATYPE_ALA          "{ala"
+#define DATATYPE_FLAG         "flag"
+#define DATATYPE_CHARSTAR     "ch8*"
+
+// key values
+#define SMC_KEY_CPU_TEMP      "TC0P"
+#define SMC_KEY_FAN_SPEED     "F%dAc"
+#define SMC_KEY_FAN_NUM       "FNum"
+#define SMC_KEY_BATTERY_TEMP  "TB0T"
+
+
+
+typedef struct SMCKeyData_vers_t {
+    char                  major;
+    char                  minor;
+    char                  build;
+    char                  reserved[1];
+    UInt16                release;
+} SMCKeyData_vers_t;
+
+typedef struct {
+    UInt16                version;
+    UInt16                length;
+    UInt32                cpuPLimit;
+    UInt32                gpuPLimit;
+    UInt32                memPLimit;
+} SMCKeyData_pLimitData_t;
+
+typedef struct {
+    UInt32                dataSize;
+    UInt32                dataType;
+    char                  dataAttributes;
+} SMCKeyData_keyInfo_t;
+
+typedef char              SMCBytes_t[32];
+
+typedef struct {
+    UInt32                  key;
+    SMCKeyData_vers_t       vers;
+    SMCKeyData_pLimitData_t pLimitData;
+    SMCKeyData_keyInfo_t    keyInfo;
+    char                    result;
+    char                    status;
+    char                    data8;
+    UInt32                  data32;
+    SMCBytes_t              bytes;
+} SMCKeyData_t;
+
+typedef char              UInt32Char_t[5];
+
+typedef char              Flag[1];
+typedef UInt8   flag;
+
+
+typedef UInt16 PWMValue;
+
+typedef struct {
+    UInt32Char_t            key;
+    UInt32                  dataSize;
+    UInt32Char_t            dataType;
+    SMCBytes_t              bytes;
+} SMCVal_t;
 
 @interface SMCWrapper : NSObject
-
 +(SMCWrapper *)sharedWrapper;
-
-// IOService Methods.
--(BOOL) SMCOpen;
--(void) SMCClose;
-
-// SMC RPC Wrappers.
--(kern_return_t) SMCReadKey:(UInt32Char_t)key
-                outputValue:(SMCVal_t *)val;
-
--(kern_return_t) SMCCall:(int)index
-              forKeyData:(SMCKeyData_t *)inputStructure
-         outputKeyDataIn:(SMCKeyData_t *)outputStructure;
-
-// String<->Unsigned Integer Helper Methods.
--(void) _ultostr:(char *)str
-          forValue:(UInt32)val;
-
--(UInt32) _strtoul:(char *)str
-           forSize:(int)size
-            inBase:(int)base;
-
-// Gets a string representation for a given SMCKeyData_t struct.
--(void) getStringRepresentation: (SMCBytes_t)bytes
-                        forSize: (UInt32)dataSize
-                         ofType: (UInt32Char_t)dataType
-                       inBuffer: (char *)str;
-
-// "Public" methods; i.e the only real methods used externally.
--(BOOL) readKey:(char *)key intoNumber:(NSNumber **)value;
--(BOOL) readKey:(char *)key asString:(NSString **)str;
-
-
+-(id) init;
+-(BOOL) stringRepresentationForBytes: (SMCBytes_t)bytes
+							withSize: (UInt32)dataSize
+							  ofType: (UInt32Char_t)dataType
+							inBuffer: (char *)str;
+-(BOOL) stringRepresentationForBytes: (SMCBytes_t)bytes
+							withSize: (UInt32)dataSize
+							  ofType: (UInt32Char_t)dataType
+						  toNSString: (NSString**)abri;
+-(BOOL) stringRepresentationOfVal:(SMCVal_t)val
+						 inBuffer: (char *)str;
+-(BOOL) stringRepresentationOfVal:(SMCVal_t)val
+					   toNSString:(NSString**)abri;
+#ifndef STRIP_COMPATIBILITY
+-(BOOL) getStringRepresentation: (SMCBytes_t)bytes
+						forSize: (UInt32)dataSize
+						 ofType: (UInt32Char_t)dataType
+					   inBuffer: (char *)str
+__deprecated_msg("Use stringRepresentationForBytes:withSize:ofType:inBuffer: instead.");
+-(BOOL) readKey:(NSString *)key
+	   asString:(NSString **)str
+__deprecated_msg("Use readKey:intoString: instead.");
+#endif
+-(BOOL) dumpToValueDict:(NSMutableDictionary**)valDict andTypeDict:(NSMutableDictionary**)typeDict;
+-(SMCVal_t) createEmptyValue;
+-(BOOL) readKey:(NSString *)key intoVal:(SMCVal_t *)val;
+-(BOOL) readKey:(NSString *)key intoString:(NSString **)str;
+-(BOOL) readKey:(NSString *)key intoNumber:(NSNumber **)value;
+-(void) dealloc;
 @end

--- a/SMCWrapper/SMCWrapper.m
+++ b/SMCWrapper/SMCWrapper.m
@@ -307,6 +307,18 @@ static SMCWrapper *sharedInstance = nil;
         snprintf(str, 15, "%d ", (signed char)*bytes);
     else if (strcmp(dataType, DATATYPE_PWM) == 0 && dataSize == 2)
         snprintf(str, 15, "%.1f%% ", ntohs(*(UInt16*)bytes) * 100 / 65536.0);
+    else if (strcmp(dataType, DATATYPE_CHARSTAR) == 0)
+        snprintf(str, 15, "%s ", bytes);
+    else if (strcmp(val.dataType, DATATYPE_FLAG) == 0)
+        snprintf(str, 15, "%s ", bytes[0] ? "TRUE" : "FALSE");
+    else {
+        int i;
+        char tempAb[64];
+        for (i = 0; i < val.dataSize; i++) {
+            snprintf(tempAb+strlen(tempAb), 8, "%02x ", (unsigned char) val.bytes[i]);
+        }
+        snprintf(str, 15, "%s ", tempAb);
+    }
 }
 
 

--- a/SMCWrapper/SMCWrapper.m
+++ b/SMCWrapper/SMCWrapper.m
@@ -1,30 +1,81 @@
-//
-//  SMCWrapper.m
-//
-//  Created by Fergus Morrow on 27/09/2014
-//  Licensed under the GNU General Public License.
+/*
+ * Apple System Management Control (SMC) Tool
+ * Copyright (C) 2006 devnull
+ * Portions Copyright (C) 2012 Alex Leigh
+ * Portions Copyright (C) 2013 Michael Wilber
+ * Portions Copyright (C) 2013 Jedda Wignall
+ * Portions Copyright (C) 2014 Perceval Faramaz
+ * Portions Copyright (C) 2014 Fergus Morrow
+ * Portions Copyright (C) 2014 Naoya Sato
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ 
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
 
-#import "SMCWrapper.h"
+#include <stdio.h>
+#include <string.h>
+#include <CoreFoundation/CoreFoundation.h>
+#include <IOKit/IOKitLib.h>
+#include <mach/machine.h>
+#include <libkern/OSAtomic.h>
+#include <cocoa/cocoa.h>
 
-@implementation SMCWrapper
+#include "smc.h"
+//#define STRIP_COMPATIBILIY
 
 // AppleSMC IOService connection
 io_connect_t conn;
 // Shared Instance (Singleton)
 static SMCWrapper *sharedInstance = nil;
 
+@interface SMCWrapper() //private methods
+-(BOOL) _smcOpen;
+-(BOOL) _smcClose;
+-(kern_return_t) _smcCall:(int)index
+			   forKeyData:(SMCKeyData_t *)inputStructure
+				toKeyData:(SMCKeyData_t *)outputStructure;
+-(kern_return_t) _smcReadKey:(UInt32Char_t)key toValue:(SMCVal_t*)val;
+-(UInt32) _strtoul:(char *)str
+		   forSize:(int)size
+			inBase:(int)base;
+-(void) _ultostr:(char *)str
+		forValue:(UInt32)val;
+-(UInt32) _smcIndexCount;
+
+#ifndef STRIP_COMPATIBILITY
+-(kern_return_t) SMCReadKey:(UInt32Char_t)key
+				outputValue:(SMCVal_t *)val
+__deprecated_msg("Use _smcReadKey:toValue: instead.");
+-(kern_return_t) SMCCall:(int)index
+			  forKeyData:(SMCKeyData_t *)inputStructure
+		 outputKeyDataIn:(SMCKeyData_t *)outputStructure
+__deprecated_msg("Use _smcCall:forKeyData: toKeyData: instead.");
+#endif
+@end
+
+@implementation SMCWrapper
 /**
- * sharedWrapper - Singleton instance retreival method.
+ * sharedWrapper - Singleton instance retrieval method. Used to get an instance of SMCWrapper.
  */
 +(SMCWrapper *) sharedWrapper{
-    if ( sharedInstance == nil ){
-        sharedInstance = [[SMCWrapper alloc] init];
-    }
-    return sharedInstance;
+	if ( sharedInstance == nil ){
+		sharedInstance = [[SMCWrapper alloc] init];
+	}
+	return sharedInstance;
 }
-
 /**
- * SMCOpen - Opens a connection (&conn) to the AppleSMC IOService.
+ * _smcOpen - Opens a connection (&conn) to the AppleSMC IOService.
  *
  * (a) Retrieve the master-port to allow RPC calls with I/O Kit.
  * (b) Attempt to get the "AppleSMC" IOService;
@@ -33,43 +84,51 @@ static SMCWrapper *sharedInstance = nil;
  *       allowing us to iterate through them
  *    - We then connect to the first matching service (via IOSericeOpen)
  */
--(BOOL) SMCOpen{
-    kern_return_t result;
-    mach_port_t   masterPort;
-    io_iterator_t iterator;
-    io_object_t   device;
-    
-    // Master port allows RPC calls for user-space code to communicate with I/O kit
-    result = IOMasterPort(MACH_PORT_NULL, &masterPort);
-    
-    // Attempt to get the AppleSMC IOService
-    CFMutableDictionaryRef matchingDictionary = IOServiceMatching("AppleSMC");
-    result = IOServiceGetMatchingServices(masterPort, matchingDictionary, &iterator);
-    if (result != kIOReturnSuccess)
-    {
-        printf("Error: IOServiceGetMatchingServices() = %08x\n", result);
-        return NO;
-    }
-    
-    // Take the first item from the IOIterator as the device, and check it's valid.
-    device = IOIteratorNext(iterator);
-    IOObjectRelease(iterator);
-    if (device == 0)
-    {
-        printf("Error: no SMC found\n");
-        return NO;
-    }
-    
-    // Open this service, saving a connection in to conn (of type io_connect_t)
-    result = IOServiceOpen(device, mach_task_self(), 0, &conn);
-    IOObjectRelease(device);
-    if (result != kIOReturnSuccess)
-    {
-        printf("Error: IOServiceOpen() = %08x\n", result);
-        return NO;
-    }
-    
-    return YES;
+-(BOOL) _smcOpen
+{
+	kern_return_t result;
+	mach_port_t   masterPort;
+	io_iterator_t iterator;
+	io_object_t   device;
+	
+	result = IOMasterPort(MACH_PORT_NULL, &masterPort);
+	
+	CFMutableDictionaryRef matchingDictionary = IOServiceMatching("AppleSMC");
+	result = IOServiceGetMatchingServices(masterPort, matchingDictionary, &iterator);
+	if (result != kIOReturnSuccess)
+	{
+		printf("Error: IOServiceGetMatchingServices() = %08x\n", result);
+		return NO;
+	}
+	
+	device = IOIteratorNext(iterator);
+	IOObjectRelease(iterator);
+	if (device == 0)
+	{
+		printf("Error: no SMC found\n");
+		return NO;
+	}
+	
+	result = IOServiceOpen(device, mach_task_self(), 0, &conn);
+	IOObjectRelease(device);
+	if (result != kIOReturnSuccess)
+	{
+		printf("Error: IOServiceOpen() = %08x\n", result);
+		return NO;
+	}
+	return YES;
+}
+
+/**
+ * _smcClose - Closes connections to the AppleSMC IOService.
+ */
+-(BOOL) _smcClose
+{
+	kern_return_t result = IOServiceClose(conn);
+	if (result == KERN_SUCCESS)
+		return true;
+	else
+		return false;
 }
 
 /**
@@ -78,20 +137,20 @@ static SMCWrapper *sharedInstance = nil;
  *  the opposite to _ultostr.
  */
 -(UInt32) _strtoul:(char *)str
-           forSize:(int)size
-            inBase:(int)base
+		   forSize:(int)size
+			inBase:(int)base
 {
-    UInt32 total = 0;
-    int i;
-    
-    for (i = 0; i < size; i++)
-    {
-        if (base == 16)
-            total += str[i] << (size - 1 - i) * 8;
-        else
-            total += (unsigned char) (str[i] << (size - 1 - i) * 8);
-    }
-    return total;
+	UInt32 total = 0;
+	int i;
+	
+	for (i = 0; i < size; i++)
+	{
+		if (base == 16)
+			total += str[i] << (size - 1 - i) * 8;
+		else
+			total += (unsigned char) (str[i] << (size - 1 - i) * 8);
+	}
+	return total;
 }
 
 /**
@@ -101,238 +160,442 @@ static SMCWrapper *sharedInstance = nil;
  *  values)
  */
 -(void) _ultostr:(char *)str
-          forValue:(UInt32)val
+		forValue:(UInt32)val
 {
-    str[0] = '\0';
-    sprintf(str, "%c%c%c%c",
-            (unsigned int) val >> 24,
-            (unsigned int) val >> 16,
-            (unsigned int) val >> 8,
-            (unsigned int) val);
+	str[0] = '\0';
+	sprintf(str, "%c%c%c%c",
+			(unsigned int) val >> 24,
+			(unsigned int) val >> 16,
+			(unsigned int) val >> 8,
+			(unsigned int) val);
 }
 
 /**
- * SMCCall:forKeyData:outputKeyDataIn - A wrapper method around
+ * _smcCall:forKeyData:toKeyData - A wrapper method around
  *  IOConnectCallStructMethod - which is responsible for IOService calls.
  */
- 
--(kern_return_t) SMCCall:(int)index
-              forKeyData:(SMCKeyData_t *)inputStructure
-         outputKeyDataIn:(SMCKeyData_t *)outputStructure
+-(kern_return_t) _smcCall:(int)index
+				 forKeyData:(SMCKeyData_t *)inputStructure
+				 toKeyData:(SMCKeyData_t *)outputStructure
 {
-    size_t   structureInputSize;
-    size_t   structureOutputSize;
-    
-    structureInputSize = sizeof(SMCKeyData_t);
-    structureOutputSize = sizeof(SMCKeyData_t);
-    
-    return IOConnectCallStructMethod( conn, index,
-                                     // inputStructure
-                                     inputStructure, structureInputSize,
-                                     // ouputStructure
-                                     outputStructure, &structureOutputSize );
+	size_t   structureInputSize;
+	size_t   structureOutputSize;
+	
+	structureInputSize = sizeof(SMCKeyData_t);
+	structureOutputSize = sizeof(SMCKeyData_t);
+	
+	return IOConnectCallStructMethod( conn, index,
+									 // inputStructure
+									 inputStructure, structureInputSize,
+									 // ouputStructure
+									 outputStructure, &structureOutputSize );
 }
-
 
 /**
- * SMCReadKey:outputValue - Reads an SMCKey (UInt32Char/char[5]), by
+ * _smcReadKey:toValue - Reads an SMCKey (UInt32Char/char[5]), by
  *  populating and maintaining to SMCKeyData structures and utilising SMCCall.
  */
--(kern_return_t) SMCReadKey:(UInt32Char_t)key
-                outputValue:(SMCVal_t *)val
+-(kern_return_t) _smcReadKey:(UInt32Char_t)key toValue:(SMCVal_t*)val
 {
-    kern_return_t result;
-    SMCKeyData_t  inputStructure;
-    SMCKeyData_t  outputStructure;
-    
-    // Blank out memory allocations for our structures
-    memset(&inputStructure, 0, sizeof(SMCKeyData_t));
-    memset(&outputStructure, 0, sizeof(SMCKeyData_t));
-    memset(val, 0, sizeof(SMCVal_t));
-    
-    // Populate our input structure with our key as an unsigned int (x32)
-    inputStructure.key = [self _strtoul:key forSize:4 inBase:16];
-    inputStructure.data8 = SMC_CMD_READ_KEYINFO;
-    
-    // Make our call and check the result.
-    result = [self SMCCall: KERNEL_INDEX_SMC
-                forKeyData: &inputStructure
-           outputKeyDataIn: &outputStructure];
-
-    
-    if (result != kIOReturnSuccess){
-        return result;
-    }
-    
-    // Populate our output structure (@todo - is this needed..?
-    //  dataSize is, afterall passed in by reference.)
-    val->dataSize = outputStructure.keyInfo.dataSize;
-
-    [self _ultostr: val->dataType
-          forValue: outputStructure.keyInfo.dataType];
-    
-    // Make our second call, with SMC_CMD_READ_BYTES to get the value,
-    //  and not KEYINFO this time.
-    inputStructure.keyInfo.dataSize = val->dataSize;
-    inputStructure.data8 = SMC_CMD_READ_BYTES;
-    
-    // Make a second call, this time with SMC_CMD_READ_BYTES set.
-    result = [self SMCCall: KERNEL_INDEX_SMC
-                forKeyData: &inputStructure
-           outputKeyDataIn: &outputStructure];
-    
-    if (result != kIOReturnSuccess){
-        return result;
-    }
-    
-    memcpy(val->bytes, outputStructure.bytes, sizeof(outputStructure.bytes));
-    return kIOReturnSuccess;
+	kern_return_t result;
+	SMCKeyData_t  inputStructure;
+	SMCKeyData_t  outputStructure;
+	
+	memset(&inputStructure, 0, sizeof(SMCKeyData_t));
+	memset(&outputStructure, 0, sizeof(SMCKeyData_t));
+	memset(val, 0, sizeof(SMCVal_t));
+	
+	inputStructure.key = [self _strtoul:key forSize:4 inBase:16];
+	inputStructure.data8 = SMC_CMD_READ_KEYINFO;
+	
+	result = [self _smcCall: KERNEL_INDEX_SMC
+				forKeyData: &inputStructure
+		   		toKeyData: &outputStructure];
+	if (result != kIOReturnSuccess)
+		return result;
+	
+	val->dataSize = outputStructure.keyInfo.dataSize;
+	[self _ultostr:val->dataType forValue:outputStructure.keyInfo.dataType];
+	inputStructure.keyInfo.dataSize = val->dataSize;
+	inputStructure.data8 = SMC_CMD_READ_BYTES;
+	
+	result = [self _smcCall:KERNEL_INDEX_SMC forKeyData:&inputStructure toKeyData:&outputStructure];
+	if (result != kIOReturnSuccess)
+		return result;
+	
+	memcpy(val->bytes, outputStructure.bytes, sizeof(outputStructure.bytes));
+	
+	return kIOReturnSuccess;
 }
 
+#ifdef WRITE_ABILITY
+-(kern_return_t) _smcWriteKey:(SMCVal_t)writeVal
+{
+	kern_return_t result;
+	SMCKeyData_t  inputStructure;
+	SMCKeyData_t  outputStructure;
+	
+	SMCVal_t      readVal;
+	
+	result = [self _smcReadKey:writeVal.key toValue:&readVal];
+	if (result != kIOReturnSuccess)
+		return result;
+	
+	if (readVal.dataSize != writeVal.dataSize) {
+		//return kIOReturnError;
+		writeVal.dataSize = readVal.dataSize;
+	}
+	
+	memset(&inputStructure, 0, sizeof(SMCKeyData_t));
+	memset(&outputStructure, 0, sizeof(SMCKeyData_t));
+	
+	inputStructure.key = [self _strtoul:writeVal.key forSize:4 inBase:16];
+	inputStructure.data8 = SMC_CMD_WRITE_BYTES;
+	inputStructure.keyInfo.dataSize = writeVal.dataSize;
+	memcpy(inputStructure.bytes, writeVal.bytes, sizeof(writeVal.bytes));
+	
+	result = [self _smcCall:KERNEL_INDEX_SMC forKeyData:&inputStructure toKeyData:&outputStructure];
+	if (result != kIOReturnSuccess)
+		return result;
+	
+	return kIOReturnSuccess;
+}
+#endif
+
+/**
+ * _smcIndexCount - Retrieves the number of keys stored in SMC
+ */
+-(UInt32) _smcIndexCount {
+	SMCVal_t val;
+	int num = 0;
+	
+	[self _smcReadKey:"#KEY" toValue:&val]; //reads the key index count
+	num = ((int)val.bytes[2] << 8) + ((unsigned)val.bytes[3] & 0xff);
+	return num;
+}
+
+#ifndef STRIP_COMPATIBILITY
+-(kern_return_t) SMCReadKey:(UInt32Char_t)key
+				outputValue:(SMCVal_t *)val
+{
+	return [self _smcReadKey:key toValue:val];
+}
+-(kern_return_t) SMCCall:(int)index
+			  forKeyData:(SMCKeyData_t *)inputStructure
+		 outputKeyDataIn:(SMCKeyData_t *)outputStructure
+{
+	return [self _smcCall:index forKeyData:inputStructure toKeyData:outputStructure];
+}
+-(BOOL) readKey:(NSString *)key asString:(NSString **)str
+{
+	return [self readKey:key intoString:str];
+}
+-(BOOL) getStringRepresentation: (SMCBytes_t)bytes
+						forSize: (UInt32)dataSize
+						 ofType: (UInt32Char_t)dataType
+					   inBuffer: (char *)str {
+	return [self stringRepresentationForBytes:bytes withSize:dataSize ofType:dataType inBuffer:str];
+}
+#endif
+
+/**
+ * createEmptyValue - Initiates an empty SMCVal_t value
+ */
+-(SMCVal_t) createEmptyValue {
+	SMCVal_t newVal;
+	memset(&newVal, 0, sizeof(newVal));
+	return newVal;
+}
+
+/**
+ * stringRepresentationForBytes:withSize:ofType:inBuffer - Retrieves a CString
+ *  representation of the given values ; returns a bool to indicate success or failure.
+ */
+-(BOOL) stringRepresentationForBytes: (SMCBytes_t)bytes
+							withSize: (UInt32)dataSize
+							  ofType: (UInt32Char_t)dataType
+					   		inBuffer: (char *)str
+{
+	if (dataSize > 0) {
+	if ((strcmp(dataType, DATATYPE_UINT8) == 0) ||
+		(strcmp(dataType, DATATYPE_UINT16) == 0) ||
+		(strcmp(dataType, DATATYPE_UINT32) == 0)) {
+		UInt32 uint= [self _strtoul:bytes forSize:dataSize inBase:10];
+		snprintf(str, 15, "%u ", (unsigned int)uint);
+	}
+	else if (strcmp(dataType, DATATYPE_FP1F) == 0 && dataSize == 2)
+		snprintf(str, 15, "%.5f ", ntohs(*(UInt16*)bytes) / 32768.0);
+	else if (strcmp(dataType, DATATYPE_FP4C) == 0 && dataSize == 2)
+		snprintf(str, 15, "%.5f ", ntohs(*(UInt16*)bytes) / 4096.0);
+	else if (strcmp(dataType, DATATYPE_FP5B) == 0 && dataSize == 2)
+		snprintf(str, 15, "%.5f ", ntohs(*(UInt16*)bytes) / 2048.0);
+	else if (strcmp(dataType, DATATYPE_FP6A) == 0 && dataSize == 2)
+		snprintf(str, 15, "%.4f ", ntohs(*(UInt16*)bytes) / 1024.0);
+	else if (strcmp(dataType, DATATYPE_FP79) == 0 && dataSize == 2)
+		snprintf(str, 15, "%.4f ", ntohs(*(UInt16*)bytes) / 512.0);
+	else if (strcmp(dataType, DATATYPE_FP88) == 0 && dataSize == 2)
+		snprintf(str, 15, "%.3f ", ntohs(*(UInt16*)bytes) / 256.0);
+	else if (strcmp(dataType, DATATYPE_FPA6) == 0 && dataSize == 2)
+		snprintf(str, 15, "%.2f ", ntohs(*(UInt16*)bytes) / 64.0);
+	else if (strcmp(dataType, DATATYPE_FPC4) == 0 && dataSize == 2)
+		snprintf(str, 15, "%.2f ", ntohs(*(UInt16*)bytes) / 16.0);
+	else if (strcmp(dataType, DATATYPE_FPE2) == 0 && dataSize == 2)
+		snprintf(str, 15, "%.2f ", ntohs(*(UInt16*)bytes) / 4.0);
+	else if (strcmp(dataType, DATATYPE_SP1E) == 0 && dataSize == 2)
+		snprintf(str, 15, "%.5f ", ((SInt16)ntohs(*(UInt16*)bytes)) / 16384.0);
+	else if (strcmp(dataType, DATATYPE_SP3C) == 0 && dataSize == 2)
+		snprintf(str, 15, "%.5f ", ((SInt16)ntohs(*(UInt16*)bytes)) / 4096.0);
+	else if (strcmp(dataType, DATATYPE_SP4B) == 0 && dataSize == 2)
+		snprintf(str, 15, "%.4f ", ((SInt16)ntohs(*(UInt16*)bytes)) / 2048.0);
+	else if (strcmp(dataType, DATATYPE_SP5A) == 0 && dataSize == 2)
+		snprintf(str, 15, "%.4f ", ((SInt16)ntohs(*(UInt16*)bytes)) / 1024.0);
+	else if (strcmp(dataType, DATATYPE_SP69) == 0 && dataSize == 2)
+		snprintf(str, 15, "%.3f ", ((SInt16)ntohs(*(UInt16*)bytes)) / 512.0);
+	else if (strcmp(dataType, DATATYPE_SP78) == 0 && dataSize == 2)
+		snprintf(str, 15, "%.3f ", ((SInt16)ntohs(*(UInt16*)bytes)) / 256.0);
+	else if (strcmp(dataType, DATATYPE_SP87) == 0 && dataSize == 2)
+		snprintf(str, 15, "%.3f ", ((SInt16)ntohs(*(UInt16*)bytes)) / 128.0);
+	else if (strcmp(dataType, DATATYPE_SP96) == 0 && dataSize == 2)
+		snprintf(str, 15, "%.2f ", ((SInt16)ntohs(*(UInt16*)bytes)) / 64.0);
+	else if (strcmp(dataType, DATATYPE_SPB4) == 0 && dataSize == 2)
+		snprintf(str, 15, "%.2f ", ((SInt16)ntohs(*(UInt16*)bytes)) / 16.0);
+	else if (strcmp(dataType, DATATYPE_SPF0) == 0 && dataSize == 2)
+		snprintf(str, 15, "%.0f ", (float)ntohs(*(UInt16*)bytes));
+	else if (strcmp(dataType, DATATYPE_SI16) == 0 && dataSize == 2)
+		snprintf(str, 15, "%d ", ntohs(*(SInt16*)bytes));
+	else if (strcmp(dataType, DATATYPE_SI8) == 0 && dataSize == 1)
+		snprintf(str, 15, "%d ", (signed char)*bytes);
+	else if (strcmp(dataType, DATATYPE_PWM) == 0 && dataSize == 2)
+		snprintf(str, 15, "%.1f%% ", ntohs(*(UInt16*)bytes) * 100 / 65536.0);
+	else if (strcmp(dataType, DATATYPE_CHARSTAR) == 0)
+		snprintf(str, 15, "%s ", bytes);
+	else if (strcmp(dataType, DATATYPE_FLAG) == 0)
+		snprintf(str, 15, "%s ", bytes[0] ? "TRUE" : "FALSE");
+	else {
+		int i;
+		char tempAb[64];
+		for (i = 0; i < dataSize; i++) {
+			snprintf(tempAb+strlen(tempAb), 8, "%02x ", (unsigned char) bytes[i]);
+		}
+		snprintf(str, 15, "%s ", tempAb);
+	}
+		return TRUE;
+	}
+	return FALSE;
+}
+
+/**
+ * stringRepresentationForBytes:withSize:ofType:toNSString - Retrieves a NSString
+ *  representation of the given values ; returns a bool to indicate success or failure.
+ */
+-(BOOL) stringRepresentationForBytes: (SMCBytes_t)bytes
+							withSize: (UInt32)dataSize
+							  ofType: (UInt32Char_t)dataType
+						  toNSString: (NSString**)abri
+{
+	if (dataSize > 0) {
+		if ((strcmp(dataType, DATATYPE_UINT8) == 0) ||
+			(strcmp(dataType, DATATYPE_UINT16) == 0) ||
+			(strcmp(dataType, DATATYPE_UINT32) == 0))
+			*abri = [[NSString alloc] initWithFormat:@"%u", (unsigned int)[self _strtoul:(char *)bytes forSize:dataSize inBase:10]];
+		else if (strcmp(dataType, DATATYPE_FP1F) == 0 && dataSize == 2)
+			*abri = [[NSString alloc] initWithFormat:@"%.5f", (ntohs(*(UInt16*)bytes) / 32768.0)];
+		else if (strcmp(dataType, DATATYPE_FP4C) == 0 && dataSize == 2)
+			*abri = [[NSString alloc] initWithFormat:@"%.5f", (ntohs(*(UInt16*)bytes) / 4096.0)];
+		else if (strcmp(dataType, DATATYPE_FP5B) == 0 && dataSize == 2)
+			*abri = [[NSString alloc] initWithFormat:@"%.5f", (ntohs(*(UInt16*)bytes) / 2048.0)];
+		else if (strcmp(dataType, DATATYPE_FP6A) == 0 && dataSize == 2)
+			*abri = [[NSString alloc] initWithFormat:@"%.4f", (ntohs(*(UInt16*)bytes) / 1024.0)];
+		else if (strcmp(dataType, DATATYPE_FP79) == 0 && dataSize == 2)
+			*abri = [[NSString alloc] initWithFormat:@"%.4f", (ntohs(*(UInt16*)bytes) / 512.0)];
+		else if (strcmp(dataType, DATATYPE_FP88) == 0 && dataSize == 2)
+			*abri = [[NSString alloc] initWithFormat:@"%.3f", (ntohs(*(UInt16*)bytes) / 256.0)];
+		else if (strcmp(dataType, DATATYPE_FPA6) == 0 && dataSize == 2)
+			*abri = [[NSString alloc] initWithFormat:@"%.2f", (ntohs(*(UInt16*)bytes) / 64.0)];
+		else if (strcmp(dataType, DATATYPE_FPC4) == 0 && dataSize == 2)
+			*abri = [[NSString alloc] initWithFormat:@"%.2f", (ntohs(*(UInt16*)bytes) / 16.0)];
+		else if (strcmp(dataType, DATATYPE_FPE2) == 0 && dataSize == 2)
+			*abri = [[NSString alloc] initWithFormat:@"%.2f", (ntohs(*(UInt16*)bytes) / 4.0)];
+		else if (strcmp(dataType, DATATYPE_SP1E) == 0 && dataSize == 2)
+			*abri = [[NSString alloc] initWithFormat:@"%.5f", (((SInt16)ntohs(*(UInt16*)bytes)) / 16384.0)];
+		else if (strcmp(dataType, DATATYPE_SP3C) == 0 && dataSize == 2)
+			*abri = [[NSString alloc] initWithFormat:@"%.5f", (((SInt16)ntohs(*(UInt16*)bytes)) / 4096.0)];
+		else if (strcmp(dataType, DATATYPE_SP4B) == 0 && dataSize == 2)
+			*abri = [[NSString alloc] initWithFormat:@"%.4f", (((SInt16)ntohs(*(UInt16*)bytes)) / 2048.0)];
+		else if (strcmp(dataType, DATATYPE_SP5A) == 0 && dataSize == 2)
+			*abri = [[NSString alloc] initWithFormat:@"%.4f", (((SInt16)ntohs(*(UInt16*)bytes)) / 1024.0)];
+		else if (strcmp(dataType, DATATYPE_SP69) == 0 && dataSize == 2)
+			*abri = [[NSString alloc] initWithFormat:@"%.3f", (((SInt16)ntohs(*(UInt16*)bytes)) / 512.0)];
+		else if (strcmp(dataType, DATATYPE_SP78) == 0 && dataSize == 2)
+			*abri = [[NSString alloc] initWithFormat:@"%.3f", (((SInt16)ntohs(*(UInt16*)bytes)) / 256.0)];
+		else if (strcmp(dataType, DATATYPE_SP87) == 0 && dataSize == 2)
+			*abri = [[NSString alloc] initWithFormat:@"%.3f", (((SInt16)ntohs(*(UInt16*)bytes)) / 128.0)];
+		else if (strcmp(dataType, DATATYPE_SP96) == 0 && dataSize == 2)
+			*abri = [[NSString alloc] initWithFormat:@"%.2f", (((SInt16)ntohs(*(UInt16*)bytes)) / 64.0)];
+		else if (strcmp(dataType, DATATYPE_SPB4) == 0 && dataSize == 2)
+			*abri = [[NSString alloc] initWithFormat:@"%.2f", (((SInt16)ntohs(*(UInt16*)bytes)) / 16.0)];
+		else if (strcmp(dataType, DATATYPE_SPF0) == 0 && dataSize == 2)
+			*abri = [[NSString alloc] initWithFormat:@"%.0f", ((float)ntohs(*(UInt16*)bytes))];
+		else if (strcmp(dataType, DATATYPE_SI8) == 0 && dataSize == 1)
+			*abri = [[NSString alloc] initWithFormat:@"%d", ((signed char)*bytes)];
+		else if (strcmp(dataType, DATATYPE_SI16) == 0 && dataSize == 2)
+			*abri = [[NSString alloc] initWithFormat:@"%d", (ntohs(*(SInt16*)bytes))];
+		else if (strcmp(dataType, DATATYPE_PWM) == 0 && dataSize == 2)
+			*abri = [[NSString alloc] initWithFormat:@"%.1f%%", (ntohs(*(UInt16*)bytes) * 100 / 65536.0)];
+		else if (strcmp(dataType, DATATYPE_CHARSTAR) == 0) {
+			*abri = [[NSString alloc] initWithFormat:@"%s", bytes];
+		}
+		else if (strcmp(dataType, DATATYPE_FLAG) == 0)
+			*abri = [[NSString alloc] initWithFormat:@"%s", bytes[0] ? "TRUE" : "FALSE"];
+		else {
+			int i;
+			char tempAb[64];
+			for (i = 0; i < dataSize; i++) {
+				snprintf(tempAb+strlen(tempAb), 8, "%02x ", (unsigned char) bytes[i]);
+			}
+			*abri = [[NSString alloc] initWithFormat:@"%s", tempAb];
+		}
+	} else {
+		return TRUE;
+	}
+	return FALSE;
+}
+
+/**
+ * stringRepresentationOfVal:inBuffer: - Retrieves a CString representation
+ * of the given SMCVal_t ; returns a bool to indicate success or failure.
+ */
+-(BOOL) stringRepresentationOfVal:(SMCVal_t)val
+						 inBuffer: (char *)str
+{
+	return [self stringRepresentationForBytes:val.bytes withSize:val.dataSize ofType:val.dataType inBuffer:str];
+}
+
+/**
+ * stringRepresentationOfVal:toNSString: - Retrieves a NSString representation
+ * of the given SMCVal_t ; returns a bool to indicate success or failure.
+ */
+-(BOOL) stringRepresentationOfVal:(SMCVal_t)val
+					   toNSString:(NSString**)abri
+{
+	return [self stringRepresentationForBytes:val.bytes withSize:val.dataSize ofType:val.dataType toNSString:abri];
+}
+
+-(BOOL) readKey:(NSString *)key intoVal:(SMCVal_t *)val {
+	kern_return_t result;
+	
+	result = [self _smcReadKey:[key UTF8String] toValue: val];
+	// Do value checking on val.
+	if (result != kIOReturnSuccess) {
+		return NO;
+	}
+	return YES;
+}
+
+/**
+ * readKey:intoString - Reads a given key from the SMC and formats the corresponding
+ *  value as an NSString (passed by reference). Returns a BOOL indicating success.
+ */
+-(BOOL) readKey:(NSString *)key intoString:(NSString **)str
+{
+	char cStr[16];   // Something has gone majorly wrong if it's over 15 digits long.
+	SMCVal_t val;
+	kern_return_t result;
+	
+	result = [self _smcReadKey:[key UTF8String] toValue: &val];
+	
+	// Do value checking on val.
+	if (result != kIOReturnSuccess) {
+		*str = [[NSString alloc] initWithFormat:@""];
+		return NO;
+	}
+	
+	// Mac OS X means rubbish FourCC style data type referencing
+	[self stringRepresentationForBytes:val.bytes
+							  withSize:val.dataType
+								ofType:val.dataType
+							  inBuffer:&cStr[0]];
+	
+	*str = [[NSString alloc] initWithCString:cStr encoding:NSUTF8StringEncoding];
+	return YES;
+}
 
 /**
  * readKey:intoNumber - Reads a given key from the SMC and formats the corresponding
  *  value as an NSNumber (passed by reference). Returns a BOOL indicating success.
  */
--(BOOL) readKey:(char *)key intoNumber:(NSNumber **)value{
-    NSString *stringVal;
-    NSNumberFormatter *f = [[NSNumberFormatter alloc] init];
-    NSNumber *num;
-    num = [NSNumber numberWithInt:0];
- 
-    if (! [self readKey:key asString:&stringVal] ){
-        num = [NSNumber numberWithInt:0];
-        *value = num;
-        return NO;
-    }
-    
-    [f setNumberStyle:NSNumberFormatterDecimalStyle];
-    num = [f numberFromString:stringVal];
-    *value = num;
-    return YES;
-}
-
-
-/**
- * readKey:asString - Reads a given key from the SMC and formats the corresponding
- *  value as an NSString (passed by reference). Returns a BOOL indicating success.
- */
--(BOOL) readKey:(char *)key asString:(NSString **)str{
-    char cStr[16];   // Something has gone majorly wrong if it's over 15 digits long.
-    SMCVal_t val;
-    kern_return_t result;
-    
-    result = [self SMCReadKey: key
-                  outputValue: &val];
-    
-    // Do value checking on val.
-    if (result != kIOReturnSuccess) {
-        *str = [[NSString alloc] initWithFormat:@""];
-        return NO;
-    }
-    
-    // Mac OS X means rubbish FourCC style data type referencing
-    [self getStringRepresentation: val.bytes
-                          forSize: val.dataSize
-                           ofType: val.dataType
-                         inBuffer: &cStr[0]];
-    
-    *str = [[NSString alloc] initWithCString:cStr encoding:NSUTF8StringEncoding];
-    return YES;
-}
-
-
-/**
- * SMCClose - Close our connection to the AppleSMC IOService.
- */
--(void) SMCClose{
-    IOServiceClose(conn);
-}
-
-
-/**
- * getStringRepresentation:forSize:ofType:inBuffer - Retrieves a C string
- *  representation of the value.
- */
--(void) getStringRepresentation: (SMCBytes_t)bytes
-                          forSize: (UInt32)dataSize
-                           ofType: (UInt32Char_t)dataType
-                         inBuffer: (char *)str
+-(BOOL) readKey:(NSString *)key intoNumber:(NSNumber **)value
 {
-    if ((strcmp(dataType, DATATYPE_UINT8) == 0) ||
-        (strcmp(dataType, DATATYPE_UINT16) == 0) ||
-        (strcmp(dataType, DATATYPE_UINT32) == 0))
-        snprintf(str, 15, "%u ", (unsigned int) [self _strtoul:bytes forSize:dataSize inBase:10]);
-    else if (strcmp(dataType, DATATYPE_FP1F) == 0 && dataSize == 2)
-        snprintf(str, 15, "%.5f ", ntohs(*(UInt16*)bytes) / 32768.0);
-    else if (strcmp(dataType, DATATYPE_FP4C) == 0 && dataSize == 2)
-        snprintf(str, 15, "%.5f ", ntohs(*(UInt16*)bytes) / 4096.0);
-    else if (strcmp(dataType, DATATYPE_FP5B) == 0 && dataSize == 2)
-        snprintf(str, 15, "%.5f ", ntohs(*(UInt16*)bytes) / 2048.0);
-    else if (strcmp(dataType, DATATYPE_FP6A) == 0 && dataSize == 2)
-        snprintf(str, 15, "%.4f ", ntohs(*(UInt16*)bytes) / 1024.0);
-    else if (strcmp(dataType, DATATYPE_FP79) == 0 && dataSize == 2)
-        snprintf(str, 15, "%.4f ", ntohs(*(UInt16*)bytes) / 512.0);
-    else if (strcmp(dataType, DATATYPE_FP88) == 0 && dataSize == 2)
-        snprintf(str, 15, "%.3f ", ntohs(*(UInt16*)bytes) / 256.0);
-    else if (strcmp(dataType, DATATYPE_FPA6) == 0 && dataSize == 2)
-        snprintf(str, 15, "%.2f ", ntohs(*(UInt16*)bytes) / 64.0);
-    else if (strcmp(dataType, DATATYPE_FPC4) == 0 && dataSize == 2)
-        snprintf(str, 15, "%.2f ", ntohs(*(UInt16*)bytes) / 16.0);
-    else if (strcmp(dataType, DATATYPE_FPE2) == 0 && dataSize == 2)
-        snprintf(str, 15, "%.2f ", ntohs(*(UInt16*)bytes) / 4.0);
-    else if (strcmp(dataType, DATATYPE_SP1E) == 0 && dataSize == 2)
-        snprintf(str, 15, "%.5f ", ((SInt16)ntohs(*(UInt16*)bytes)) / 16384.0);
-    else if (strcmp(dataType, DATATYPE_SP3C) == 0 && dataSize == 2)
-        snprintf(str, 15, "%.5f ", ((SInt16)ntohs(*(UInt16*)bytes)) / 4096.0);
-    else if (strcmp(dataType, DATATYPE_SP4B) == 0 && dataSize == 2)
-        snprintf(str, 15, "%.4f ", ((SInt16)ntohs(*(UInt16*)bytes)) / 2048.0);
-    else if (strcmp(dataType, DATATYPE_SP5A) == 0 && dataSize == 2)
-        snprintf(str, 15, "%.4f ", ((SInt16)ntohs(*(UInt16*)bytes)) / 1024.0);
-    else if (strcmp(dataType, DATATYPE_SP69) == 0 && dataSize == 2)
-        snprintf(str, 15, "%.3f ", ((SInt16)ntohs(*(UInt16*)bytes)) / 512.0);
-    else if (strcmp(dataType, DATATYPE_SP78) == 0 && dataSize == 2)
-        snprintf(str, 15, "%.3f ", ((SInt16)ntohs(*(UInt16*)bytes)) / 256.0);
-    else if (strcmp(dataType, DATATYPE_SP87) == 0 && dataSize == 2)
-        snprintf(str, 15, "%.3f ", ((SInt16)ntohs(*(UInt16*)bytes)) / 128.0);
-    else if (strcmp(dataType, DATATYPE_SP96) == 0 && dataSize == 2)
-        snprintf(str, 15, "%.2f ", ((SInt16)ntohs(*(UInt16*)bytes)) / 64.0);
-    else if (strcmp(dataType, DATATYPE_SPB4) == 0 && dataSize == 2)
-        snprintf(str, 15, "%.2f ", ((SInt16)ntohs(*(UInt16*)bytes)) / 16.0);
-    else if (strcmp(dataType, DATATYPE_SPF0) == 0 && dataSize == 2)
-        snprintf(str, 15, "%.0f ", (float)ntohs(*(UInt16*)bytes));
-    else if (strcmp(dataType, DATATYPE_SI16) == 0 && dataSize == 2)
-        snprintf(str, 15, "%d ", ntohs(*(SInt16*)bytes));
-    else if (strcmp(dataType, DATATYPE_SI8) == 0 && dataSize == 1)
-        snprintf(str, 15, "%d ", (signed char)*bytes);
-    else if (strcmp(dataType, DATATYPE_PWM) == 0 && dataSize == 2)
-        snprintf(str, 15, "%.1f%% ", ntohs(*(UInt16*)bytes) * 100 / 65536.0);
-    else if (strcmp(dataType, DATATYPE_CHARSTAR) == 0)
-        snprintf(str, 15, "%s ", bytes);
-    else if (strcmp(val.dataType, DATATYPE_FLAG) == 0)
-        snprintf(str, 15, "%s ", bytes[0] ? "TRUE" : "FALSE");
-    else {
-        int i;
-        char tempAb[64];
-        for (i = 0; i < val.dataSize; i++) {
-            snprintf(tempAb+strlen(tempAb), 8, "%02x ", (unsigned char) val.bytes[i]);
-        }
-        snprintf(str, 15, "%s ", tempAb);
-    }
+	NSString *stringVal;
+	NSNumberFormatter *f = [[NSNumberFormatter alloc] init];
+	NSNumber *num;
+	num = [NSNumber numberWithInt:0];
+ 
+	if (! [self readKey:key intoString:&stringVal] ){
+		num = [NSNumber numberWithInt:0];
+		*value = num;
+		return NO;
+	}
+	
+	[f setNumberStyle:NSNumberFormatterDecimalStyle];
+	num = [f numberFromString:stringVal];
+	*value = num;
+	return YES;
 }
 
+-(BOOL) dumpToValueDict:(NSMutableDictionary**)valDict andTypeDict:(NSMutableDictionary**)typeDict {
+	kern_return_t result;
+	SMCKeyData_t  inputStructure;
+	SMCKeyData_t  outputStructure;
+	
+	int           totalKeys=0, i=0;
+	UInt32Char_t  key;
+	SMCVal_t      val;
+	NSString* stringKey;
+	NSString* valueKey;
+	NSString* typeKey;
+	*valDict=[[NSMutableDictionary alloc] init];
+	*typeDict=[[NSMutableDictionary alloc] init];
+	totalKeys = [self _smcIndexCount];
+	for (i = 0; i < totalKeys; i++) {
+		//zeroing out structures
+		memset(&inputStructure, 0, sizeof(SMCKeyData_t));
+		memset(&outputStructure, 0, sizeof(SMCKeyData_t));
+		memset(&val, 0, sizeof(SMCVal_t));
+		//setting parameters in structures (to read the name of the key we're looking for, by its ID, which here is =i)
+		inputStructure.data8 = SMC_CMD_READ_INDEX;
+		inputStructure.data32 = i;
+		
+		//makes call to AppleSMC IOService
+		result = [self _smcCall:KERNEL_INDEX_SMC forKeyData:&inputStructure toKeyData:&outputStructure];
+		if (result != kIOReturnSuccess)
+			continue;
+		
+		[self _ultostr:key forValue:outputStructure.key];
+		
+		result = [self _smcReadKey:key toValue:&val]; //reads key (by its name, see above)
+		stringKey = [NSString stringWithFormat:@"%s" , key];
+		[self stringRepresentationOfVal:val toNSString:&valueKey];
 
--(id) init{
-    if (self = [super init]){
-        if (![self SMCOpen]){
-            NSLog(@"Unable to open SMC.");
-        }
-    }
-    return self;
+		typeKey = [NSString stringWithFormat:@"%-4s",val.dataType];
+		[*valDict setObject:valueKey forKey:stringKey];
+		[*typeDict setObject:typeKey forKey:stringKey];
+	}
+	return TRUE;
 }
 
--(void) dealloc{
-    [self SMCClose];
+-(id) init
+{
+	self = [super init];
+	if (self) {
+		[self _smcOpen]; //open connection to AppleSMC IOService
+	}
+	return self;
+}
+
+-(void) dealloc
+{
+	[self _smcClose]; //closes connection to AppleSMC IOService
 }
 
 @end

--- a/SMCWrapper/smc.h
+++ b/SMCWrapper/smc.h
@@ -57,11 +57,14 @@
 #define DATATYPE_SI8          "si8 "
 #define DATATYPE_SI16         "si16"
 
+#define DATATYPE_FLAG         "flag"
+#define DATATYPE_CHARSTAR     "ch8*"
 #define DATATYPE_PWM          "{pwm"
 
 // @todo: document these structures/types and work out
 //  where they're utilised.
-typedef struct {
+
+typedef struct SMCKeyData_vers_t{ //used to identify SMC firmware version
     char                  major;
     char                  minor;
     char                  build;


### PR DESCRIPTION
Hi !
I refactored the code, adding functions, making other ones deprecated (but keeping support), and made the interface a bit more consistent (across function names, e.g. readKey:AsString, but readKey:intoNumber).
I made some functions private, and added an underline to distinguish them.
Here are the details : 
- Renamed and made private IOService functions (_smcOpen, _smcClose, _smcCall)
- Helper functions (_strtoul, _ultostr) are private too
- Deprecated : 
  - SMCReadKey:outputValue (replaced by _smcReadKey:toValue:)
  - SMCCall:forKeyData:outputKeyDataIn (by _smcCall:forKeyData:toKeyData )
  - getStringRepresentation:forSize:ofType:inBuffer (became stringRepresentationForBytes:withSize:ofType:inBuffer:)
  - readKey:AsString: (by readKey:IntoString) _not sure about this one, tell me how you feel_
- Added :
  - `-(UInt32) _smcIndexCount;`
  - `-(BOOL) dumpToValueDict:(NSMutableDictionary**)valDict andTypeDict:(NSMutableDictionary**)typeDict;`
  - `-(SMCVal_t) createEmptyValue;`
  - `-(BOOL) readKey:(NSString *)key intoVal:(SMCVal_t *)val;`
  - `-(BOOL) stringRepresentationForBytes: (SMCBytes_t)bytes
                          withSize: (UInt32)dataSize
                            ofType: (UInt32Char_t)dataType
                          inBuffer: (char *)str;`
  - `-(BOOL) stringRepresentationForBytes: (SMCBytes_t)bytes
                          withSize: (UInt32)dataSize
                            ofType: (UInt32Char_t)dataType
                        toNSString: (NSString**)abri;`
  - `-(BOOL) stringRepresentationOfVal:(SMCVal_t)val
                       inBuffer: (char *)str;`
  - `-(BOOL) stringRepresentationOfVal:(SMCVal_t)val
                     toNSString:(NSString**)abri;`
